### PR TITLE
add command line parsing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module hugobde.dev/goob
 go 1.22.0
 
 require (
-	github.com/a-h/templ v0.2.598 // indirect
-	nhooyr.io/websocket v1.8.10 // indirect
+	github.com/a-h/templ v0.2.598
+	nhooyr.io/websocket v1.8.10
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/a-h/templ v0.2.598 h1:6jMIHv6wQZvdPxTuv87erW4RqN/FPU0wk7ZHN5wVuuo=
 github.com/a-h/templ v0.2.598/go.mod h1:SA7mtYwVEajbIXFRh3vKdYm/4FYyLQAtPH1+KxzGPA8=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 nhooyr.io/websocket v1.8.10 h1:mv4p+MnGrLDcPlBoWsvPP7XCzTYMXP9F9eIGoKbgx7Q=
 nhooyr.io/websocket v1.8.10/go.mod h1:rN9OFWIUwuxg4fR5tELlYC04bXYowCP9GX47ivo2l+c=


### PR DESCRIPTION
Added the following command line flags:
help: print usage message
cert: specify the TLS certificate to use
key: specify the TLS private key to use
port: specify the port to listen on

specifying cert and key together enables TLS
only specifying results in an error
not specifying them disables TLS